### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.umbrello.json
+++ b/org.kde.umbrello.json
@@ -23,7 +23,9 @@
     ],
     "cleanup": [
         "/include",
-        "/lib/cmake"
+        "/lib/cmake",
+        "/share/doc",
+        "/share/man"
     ],
     "modules": [
         {


### PR DESCRIPTION
The installed size reduced from 19.2 MB to 14.6 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.